### PR TITLE
unittestの修正＆バリデーションロジックのご提案

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,6 @@
 >
     <testsuites>
         <testsuite name="Package Test Suite">
-            <file>./tests/BeforeLoadAllowNonRfcComplaintEmailPatchTest.php</file>
             <file>./tests/AllowNonRfcComplaintEmailPatchTest.php</file>
         </testsuite>
     </testsuites>

--- a/src/AllowNonRfcComplaintEmailValidator.php
+++ b/src/AllowNonRfcComplaintEmailValidator.php
@@ -12,13 +12,6 @@ class AllowNonRfcComplaintEmailValidator extends \Egulias\EmailValidator\EmailVa
      */
     public function isValid($email, \Egulias\EmailValidator\Validation\EmailValidation $emailValidation)
     {
-        if (substr_count($email, '@') < 1) {
-            return false;
-        }
-        list($account, $domain) = explode('@', $email);
-        if (strlen($account) > 0 && strlen($domain) > 0) {
-            return true;
-        }
-        return false;
+        return (bool)preg_match('/^.+@.+$/', $email);
     }
 }


### PR DESCRIPTION
パッケージ作成ありがとうございます。
Qiita記事も読ませていただきました。

手元で動作させてみた際に`composer test`にて警告/エラーが発生した箇所を修正してみました。ご確認お願いします。

## 動作環境
PHP 7.3.11

## 変更内容
* phpunit.xml
  * syntaxCheckの削除 [参考](https://stackoverflow.com/questions/44328114/phpunit-what-does-syntaxcheck-configuration-parameter-stands-for-exactly/44331140#44331140)
  * 参照できないファイルの指定削除
* validationロジックのご提案
  * `@`の両サイドに1文字以上含まれていれば許可という仕様に基づいた正規表現を試してみました
* 検証に伴いテストパターンを少し追加させていただきました

宜しくお願いします。